### PR TITLE
Add prompt viewer pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@mantine/hooks": "^7.17.3",
         "@tabler/icons-react": "^3.31.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -1148,6 +1149,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3033,6 +3043,38 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@mantine/hooks": "^7.17.3",
     "@tabler/icons-react": "^3.31.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,65 +1,15 @@
-// Removed useState, logos, and default App.css import.
-// Keep './App.css' import below if you add global styles specific to App later.
-import { Box, Group, ActionIcon, Anchor, Tooltip } from '@mantine/core';
-import { IconBrandGithub, IconDownload } from '@tabler/icons-react';
-import classes from './App.module.css'; // Import App-specific styles
-// Keep './App.css' import below if you add global styles specific to App later.
-// import './App.css'
-import HeroSection from './components/HeroSection'; // Import the HeroSection
-import WorkflowOverview from './components/WorkflowOverview'; // Import the overall workflow section
-import PromptsShowcase from './components/PromptsShowcase'; // Import the combined showcase
-// Removed FeaturesOverview import
-import OtherFeatures from './components/OtherFeatures'; // Import the new OtherFeatures component
-import CTASection from './components/CTASection'; // Import the CTASection
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import LandingPage from './pages/LandingPage';
+import PromptPage from './pages/PromptPage';
 
-/**
- * @description
- * Main application component for the Kornelius marketing site.
- * It sets up the main layout and renders the different sections of the page.
- * Currently, it only renders the HeroSection. Other sections will be added sequentially.
- *
- * @dependencies
- * - React: Base library.
- * - HeroSection: The first content section of the page.
- * - PromptsShowcase: Section displaying prompt links grouped by mode.
- * - OtherFeatures: Section for miscellaneous features.
- * - CTASection: The final call-to-action section.
- *
- * @notes
- * - This component renders the main sections of the single-page application.
- */
 function App() {
-  const githubUrl = "https://github.com/scragz/kornelius";
-  const downloadUrl = "https://github.com/scragz/kornelius/releases/download/v0.1.12/kornelius-0.1.12.vsix";
-
   return (
-    <>
-      <Box className={classes.fixedIcons}>
-        <Group gap="sm">
-          <Tooltip label="View on GitHub" withArrow position="bottom-end">
-            <Anchor href={githubUrl} target="_blank" rel="noopener noreferrer">
-              <ActionIcon variant="transparent" size="lg" className={classes.iconLink}>
-                <IconBrandGithub size={28} />
-              </ActionIcon>
-            </Anchor>
-          </Tooltip>
-          <Tooltip label="Get Extension" withArrow position="bottom-end">
-            <Anchor href={downloadUrl} target="_blank" rel="noopener noreferrer">
-              <ActionIcon variant="transparent" size="lg" className={classes.iconLink}>
-                <IconDownload size={28} />
-              </ActionIcon>
-            </Anchor>
-          </Tooltip>
-        </Group>
-      </Box>
-
-      <HeroSection />
-      <WorkflowOverview /> {/* Render the overall workflow section */}
-      <PromptsShowcase /> {/* Render the grouped prompts section */}
-      <OtherFeatures /> {/* Render the miscellaneous features section */}
-      <CTASection /> {/* Render the CTASection */}
-      {/* Other sections will be added here later: */}
-    </>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/prompt/:id" element={<PromptPage />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/src/components/GitHubPromptCard.tsx
+++ b/src/components/GitHubPromptCard.tsx
@@ -22,19 +22,20 @@
  */
 import React, { useState, useCallback } from 'react';
 import { Card, Text, Group, Tooltip, ActionIcon, Anchor } from '@mantine/core';
+import { Link } from 'react-router-dom';
 import { IconCopy, IconCheck, IconAlertCircle, IconLoader } from '@tabler/icons-react';
 import classes from './GitHubPromptCard.module.css'; // Import CSS module
 
 interface GitHubPromptCardProps {
+  id: string;
   title: string;
-  viewUrl: string; // URL to the prompt file view on GitHub
-  rawUrl: string; // URL to the raw prompt text file for fetching
-  description?: string; // Optional description
+  rawUrl: string;
+  description?: string;
 }
 
 type CopyState = 'idle' | 'loading' | 'success' | 'error';
 
-const GitHubPromptCard: React.FC<GitHubPromptCardProps> = ({ title, viewUrl, rawUrl, description }) => {
+const GitHubPromptCard: React.FC<GitHubPromptCardProps> = ({ id, title, rawUrl, description }) => {
   const [copyState, setCopyState] = useState<CopyState>('idle');
 
   const handleFetchAndCopy = useCallback(async (event: React.MouseEvent) => {
@@ -84,12 +85,11 @@ const GitHubPromptCard: React.FC<GitHubPromptCardProps> = ({ title, viewUrl, raw
     <Card shadow="sm" padding="lg" radius="md" withBorder className={classes.card}>
       <Group justify="space-between" align="flex-start" wrap="nowrap" className={classes.contentGroup}>
         <Anchor
-          href={viewUrl}
-          target="_blank"
-          rel="noopener noreferrer"
+          component={Link}
+          to={`/prompt/${id}`}
           fz="lg"
           fw={700}
-          className={classes.titleLink} // Apply class from CSS module
+          className={classes.titleLink}
         >
           {title}
         </Anchor>

--- a/src/components/PromptHeader.module.css
+++ b/src/components/PromptHeader.module.css
@@ -1,0 +1,32 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-bottom: 2px solid var(--comment-color, #8b949e);
+  background-color: rgba(20, 20, 20, 0.7);
+  backdrop-filter: blur(4px);
+}
+
+.logoLink {
+  text-decoration: none;
+  color: inherit;
+}
+
+.logoImage {
+  width: 40px;
+  height: auto;
+}
+
+.title {
+  font-family: 'Bungee', sans-serif;
+  color: var(--keyword-color, #ff7b72);
+}
+
+.iconLink {
+  color: var(--comment-color, #8b949e);
+}
+
+.iconLink:hover {
+  color: var(--type-color, #79c0ff);
+}

--- a/src/components/PromptHeader.tsx
+++ b/src/components/PromptHeader.tsx
@@ -1,0 +1,25 @@
+import { ActionIcon, Anchor, Group, Image, Title } from '@mantine/core';
+import { IconBrandGithub } from '@tabler/icons-react';
+import { Link } from 'react-router-dom';
+import classes from './PromptHeader.module.css';
+import logo from '../assets/images/barbed-wire-color.svg';
+
+const githubUrl = 'https://github.com/scragz/kornelius';
+
+const PromptHeader = () => (
+  <header className={classes.header}>
+    <Anchor component={Link} to="/" className={classes.logoLink}>
+      <Group gap="xs">
+        <Image src={logo} alt="Logo" className={classes.logoImage} />
+        <Title order={3} className={classes.title}>KoЯnelius</Title>
+      </Group>
+    </Anchor>
+    <Anchor href={githubUrl} target="_blank" rel="noopener noreferrer">
+      <ActionIcon variant="transparent" size="lg" className={classes.iconLink}>
+        <IconBrandGithub size={28} />
+      </ActionIcon>
+    </Anchor>
+  </header>
+);
+
+export default PromptHeader;

--- a/src/components/PromptsShowcase.tsx
+++ b/src/components/PromptsShowcase.tsx
@@ -17,36 +17,14 @@
  * - Styling for the grid layout and titles needs to be applied to match the theme.
  */
 import React from 'react';
-import { Container, Title, SimpleGrid } from '@mantine/core'; // Removed Image, Box
-import GitHubPromptCard from './GitHubPromptCard'; // Import the prompt card component
-import classes from './PromptsShowcase.module.css'; // Import CSS module
+import { Container, Title, SimpleGrid } from '@mantine/core';
+import GitHubPromptCard from './GitHubPromptCard';
+import classes from './PromptsShowcase.module.css';
+import { prompts } from '../data/prompts';
 
-// Base URLs for GitHub view and raw content
-const GITHUB_VIEW_BASE_URL = 'https://github.com/scragz/kornelius/blob/main/prompts';
-const GITHUB_RAW_BASE_URL = 'https://raw.githubusercontent.com/scragz/kornelius/main/prompts';
-
-// Data for prompts including both view and raw URLs
-const allPrompts = [
-  // Create Mode
-  { id: 'create-req', title: 'Create: Request', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/request.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/request.prompt`, description: 'Define the initial request for code generation.' },
-  { id: 'create-spec', title: 'Create: Spec', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/spec.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/spec.prompt`, description: 'Generate a technical specification from a request.' },
-  { id: 'create-plan', title: 'Create: Planner', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/planner.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/planner.prompt`, description: 'Create an implementation plan based on a spec.' },
-  { id: 'create-code', title: 'Create: Codegen', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/codegen.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/codegen.prompt`, description: 'Generate code based on a plan and spec.' },
-  { id: 'create-rev', title: 'Create: Review', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/review.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/review.prompt`, description: 'Review generated code for improvements.' },
-  // Debug Mode
-  { id: 'debug-obs', title: 'Debug: Observe', viewUrl: `${GITHUB_VIEW_BASE_URL}/debug/observe.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/debug/observe.prompt`, description: 'Analyze code and identify potential issues.' },
-  { id: 'debug-ori', title: 'Debug: Orient', viewUrl: `${GITHUB_VIEW_BASE_URL}/debug/orient.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/debug/orient.prompt`, description: 'Formulate hypotheses about the root cause.' },
-  { id: 'debug-dec', title: 'Debug: Decide', viewUrl: `${GITHUB_VIEW_BASE_URL}/debug/decide.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/debug/decide.prompt`, description: 'Propose specific debugging actions or fixes.' },
-  { id: 'debug-act', title: 'Debug: Act', viewUrl: `${GITHUB_VIEW_BASE_URL}/debug/act.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/debug/act.prompt`, description: 'Generate code patches or refactoring suggestions.' },
-  // Audit Mode
-  { id: 'audit-sec', title: 'Audit: Security', viewUrl: `${GITHUB_VIEW_BASE_URL}/audit/security.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/audit/security.prompt`, description: 'Perform a security audit on the provided code.' },
-  { id: 'audit-acc', title: 'Audit: Accessibility', viewUrl: `${GITHUB_VIEW_BASE_URL}/audit/a11y.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/audit/a11y.prompt`, description: 'Perform an accessibility audit.' },
-];
-
-// Filter prompts by mode based on title prefix
-const createPrompts = allPrompts.filter(p => p.title.startsWith('Create:'));
-const debugPrompts = allPrompts.filter(p => p.title.startsWith('Debug:'));
-const auditPrompts = allPrompts.filter(p => p.title.startsWith('Audit:'));
+const createPrompts = prompts.filter(p => p.title.startsWith('Create:'));
+const debugPrompts = prompts.filter(p => p.title.startsWith('Debug:'));
+const auditPrompts = prompts.filter(p => p.title.startsWith('Audit:'));
 
 
 const PromptsShowcase: React.FC = () => {
@@ -62,8 +40,8 @@ const PromptsShowcase: React.FC = () => {
         {createPrompts.map((prompt) => (
           <GitHubPromptCard
             key={prompt.id}
-            title={prompt.title.replace('Create: ', '')} // Remove prefix for display
-            viewUrl={prompt.viewUrl}
+            id={prompt.id}
+            title={prompt.title.replace('Create: ', '')}
             rawUrl={prompt.rawUrl}
             description={prompt.description}
           />
@@ -78,8 +56,8 @@ const PromptsShowcase: React.FC = () => {
         {debugPrompts.map((prompt) => (
           <GitHubPromptCard
             key={prompt.id}
-            title={prompt.title.replace('Debug: ', '')} // Remove prefix
-            viewUrl={prompt.viewUrl}
+            id={prompt.id}
+            title={prompt.title.replace('Debug: ', '')}
             rawUrl={prompt.rawUrl}
             description={prompt.description}
           />
@@ -94,8 +72,8 @@ const PromptsShowcase: React.FC = () => {
         {auditPrompts.map((prompt) => (
           <GitHubPromptCard
             key={prompt.id}
-            title={prompt.title.replace('Audit: ', '')} // Remove prefix
-            viewUrl={prompt.viewUrl}
+            id={prompt.id}
+            title={prompt.title.replace('Audit: ', '')}
             rawUrl={prompt.rawUrl}
             description={prompt.description}
           />

--- a/src/data/prompts.ts
+++ b/src/data/prompts.ts
@@ -1,0 +1,24 @@
+export interface Prompt {
+  id: string;
+  title: string;
+  viewUrl: string;
+  rawUrl: string;
+  description: string;
+}
+
+export const GITHUB_VIEW_BASE_URL = 'https://github.com/scragz/kornelius/blob/main/prompts';
+export const GITHUB_RAW_BASE_URL = 'https://raw.githubusercontent.com/scragz/kornelius/main/prompts';
+
+export const prompts: Prompt[] = [
+  { id: 'create-req', title: 'Create: Request', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/request.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/request.prompt`, description: 'Define the initial request for code generation.' },
+  { id: 'create-spec', title: 'Create: Spec', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/spec.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/spec.prompt`, description: 'Generate a technical specification from a request.' },
+  { id: 'create-plan', title: 'Create: Planner', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/planner.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/planner.prompt`, description: 'Create an implementation plan based on a spec.' },
+  { id: 'create-code', title: 'Create: Codegen', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/codegen.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/codegen.prompt`, description: 'Generate code based on a plan and spec.' },
+  { id: 'create-rev', title: 'Create: Review', viewUrl: `${GITHUB_VIEW_BASE_URL}/create/review.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/create/review.prompt`, description: 'Review generated code for improvements.' },
+  { id: 'debug-obs', title: 'Debug: Observe', viewUrl: `${GITHUB_VIEW_BASE_URL}/debug/observe.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/debug/observe.prompt`, description: 'Analyze code and identify potential issues.' },
+  { id: 'debug-ori', title: 'Debug: Orient', viewUrl: `${GITHUB_VIEW_BASE_URL}/debug/orient.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/debug/orient.prompt`, description: 'Formulate hypotheses about the root cause.' },
+  { id: 'debug-dec', title: 'Debug: Decide', viewUrl: `${GITHUB_VIEW_BASE_URL}/debug/decide.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/debug/decide.prompt`, description: 'Propose specific debugging actions or fixes.' },
+  { id: 'debug-act', title: 'Debug: Act', viewUrl: `${GITHUB_VIEW_BASE_URL}/debug/act.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/debug/act.prompt`, description: 'Generate code patches or refactoring suggestions.' },
+  { id: 'audit-sec', title: 'Audit: Security', viewUrl: `${GITHUB_VIEW_BASE_URL}/audit/security.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/audit/security.prompt`, description: 'Perform a security audit on the provided code.' },
+  { id: 'audit-acc', title: 'Audit: Accessibility', viewUrl: `${GITHUB_VIEW_BASE_URL}/audit/a11y.prompt`, rawUrl: `${GITHUB_RAW_BASE_URL}/audit/a11y.prompt`, description: 'Perform an accessibility audit.' },
+];

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,0 +1,45 @@
+import { Box, Group, ActionIcon, Anchor, Tooltip } from '@mantine/core';
+import { IconBrandGithub, IconDownload } from '@tabler/icons-react';
+import classes from '../App.module.css';
+import HeroSection from '../components/HeroSection';
+import WorkflowOverview from '../components/WorkflowOverview';
+import PromptsShowcase from '../components/PromptsShowcase';
+import OtherFeatures from '../components/OtherFeatures';
+import CTASection from '../components/CTASection';
+
+const LandingPage = () => {
+  const githubUrl = 'https://github.com/scragz/kornelius';
+  const downloadUrl =
+    'https://github.com/scragz/kornelius/releases/download/v0.1.12/kornelius-0.1.12.vsix';
+
+  return (
+    <>
+      <Box className={classes.fixedIcons}>
+        <Group gap="sm">
+          <Tooltip label="View on GitHub" withArrow position="bottom-end">
+            <Anchor href={githubUrl} target="_blank" rel="noopener noreferrer">
+              <ActionIcon variant="transparent" size="lg" className={classes.iconLink}>
+                <IconBrandGithub size={28} />
+              </ActionIcon>
+            </Anchor>
+          </Tooltip>
+          <Tooltip label="Get Extension" withArrow position="bottom-end">
+            <Anchor href={downloadUrl} target="_blank" rel="noopener noreferrer">
+              <ActionIcon variant="transparent" size="lg" className={classes.iconLink}>
+                <IconDownload size={28} />
+              </ActionIcon>
+            </Anchor>
+          </Tooltip>
+        </Group>
+      </Box>
+
+      <HeroSection />
+      <WorkflowOverview />
+      <PromptsShowcase />
+      <OtherFeatures />
+      <CTASection />
+    </>
+  );
+};
+
+export default LandingPage;

--- a/src/pages/PromptPage.module.css
+++ b/src/pages/PromptPage.module.css
@@ -1,0 +1,4 @@
+.codeBlock {
+  font-size: 1rem;
+  white-space: pre-wrap;
+}

--- a/src/pages/PromptPage.tsx
+++ b/src/pages/PromptPage.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Code, Container, Loader } from '@mantine/core';
+import PromptHeader from '../components/PromptHeader';
+import { prompts } from '../data/prompts';
+import classes from './PromptPage.module.css';
+
+const PromptPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const prompt = prompts.find((p) => p.id === id);
+
+  const [content, setContent] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (!prompt) {
+      setLoading(false);
+      return;
+    }
+    fetch(prompt.rawUrl)
+      .then((res) => res.text())
+      .then((text) => setContent(text))
+      .catch(() => setContent('Failed to load prompt.'))
+      .finally(() => setLoading(false));
+  }, [prompt]);
+
+  return (
+    <>
+      <PromptHeader />
+      <Container size="md" my="xl">
+        <h2>{prompt ? prompt.title : 'Not Found'}</h2>
+        {loading ? (
+          <Loader />
+        ) : (
+          <Code block className={classes.codeBlock}>{content}</Code>
+        )}
+      </Container>
+    </>
+  );
+};
+
+export default PromptPage;


### PR DESCRIPTION
## Summary
- add React Router setup and landing page component
- add prompt list data
- add prompt viewer page with header
- link prompt cards to internal pages
- provide layout header with logo and GitHub link

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684603c64e20833095d46f19c01cfa58