### PR TITLE
Fix header logo styling

### DIFF
--- a/src/components/HeroSection.module.css
+++ b/src/components/HeroSection.module.css
@@ -29,18 +29,13 @@
 }
 
 .barbedWireLogo {
-  width: 80%; /* Make it large */
-  max-width: 600px; /* Max size */
-  opacity: 0.5; /* Make it slightly transparent */
-  position: absolute; /* Position behind */
-  top: 35%; /* Move it up significantly */
-  left: 50%;
-  transform: translate(-50%, -50%) rotate(-10deg); /* Center horizontally, adjust vertical and rotation */
-  z-index: 0; /* Behind title but above background */
-  filter: drop-shadow(5px 7px 5px rgb(0 0 0 / 0.6));
-  opacity: 0.3; /* Make it more subtle */
-  width: 60%; /* Slightly smaller */
+  width: 60%;
   max-width: 500px;
+  position: absolute;
+  top: 35%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-10deg);
+  filter: drop-shadow(5px 7px 5px rgb(0 0 0 / 0.6));
 }
 
 /* Remove unused styles */

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -18,6 +18,7 @@ import { Container, Title, Text, Box, Button, Stack } from '@mantine/core';
 import React from 'react';
 import { IconArrowDown } from '@tabler/icons-react';
 import classes from './HeroSection.module.css';
+import logoClasses from './shared/Logo.module.css';
 import logo from '../assets/images/barbed-wire-color.svg';
 
 const HeroSection: React.FC = () => {
@@ -33,17 +34,19 @@ const HeroSection: React.FC = () => {
     <Box className={classes.heroBox}>
       <Container size="md" className={classes.heroContainer}>
         <Stack align="center" gap="xl">
-          {/* Barbed Wire Image */}
-          <img
-            src={logo}
-            alt="Barbed Wire Logo"
-            className={classes.barbedWireLogo}
-          />
+          <div className={logoClasses.logoContainer}>
+            {/* Barbed Wire Image */}
+            <img
+              src={logo}
+              alt="Barbed Wire Logo"
+              className={`${logoClasses.barbedWire} ${classes.barbedWireLogo}`}
+            />
 
-          {/* Headline */}
-          <Title order={1} className={classes.heroTitle}>
-            KoЯnelius
-          </Title>
+            {/* Headline */}
+            <Title order={1} className={`${logoClasses.logoText} ${classes.heroTitle}`}>
+              KoЯnelius
+            </Title>
+          </div>
 
           {/* Tagline */}
           <Text size="xl" className={classes.heroTagline}>

--- a/src/components/PromptHeader.module.css
+++ b/src/components/PromptHeader.module.css
@@ -13,14 +13,20 @@
   color: inherit;
 }
 
-.logoImage {
-  width: 40px;
+
+.logoContainer {
+  position: relative;
+  width: 120px;
+  height: 35px;
+}
+
+.barbedWireSmall {
+  width: 100%;
   height: auto;
 }
 
 .title {
   font-family: 'Bungee', sans-serif;
-  color: var(--keyword-color, #ff7b72);
 }
 
 .iconLink {

--- a/src/components/PromptHeader.tsx
+++ b/src/components/PromptHeader.tsx
@@ -1,7 +1,8 @@
-import { ActionIcon, Anchor, Group, Image, Title } from '@mantine/core';
+import { ActionIcon, Anchor, Group, Title } from '@mantine/core';
 import { IconBrandGithub } from '@tabler/icons-react';
 import { Link } from 'react-router-dom';
 import classes from './PromptHeader.module.css';
+import logoClasses from './shared/Logo.module.css';
 import logo from '../assets/images/barbed-wire-color.svg';
 
 const githubUrl = 'https://github.com/scragz/kornelius';
@@ -10,8 +11,10 @@ const PromptHeader = () => (
   <header className={classes.header}>
     <Anchor component={Link} to="/" className={classes.logoLink}>
       <Group gap="xs">
-        <Image src={logo} alt="Logo" className={classes.logoImage} />
-        <Title order={3} className={classes.title}>KoЯnelius</Title>
+        <div className={`${logoClasses.logoContainer} ${classes.logoContainer}`}>
+          <img src={logo} alt="Logo" className={`${logoClasses.barbedWire} ${classes.barbedWireSmall}`} />
+          <Title order={3} className={`${logoClasses.logoText} ${classes.title}`}>KoЯnelius</Title>
+        </div>
       </Group>
     </Anchor>
     <Anchor href={githubUrl} target="_blank" rel="noopener noreferrer">

--- a/src/components/shared/Logo.module.css
+++ b/src/components/shared/Logo.module.css
@@ -1,0 +1,41 @@
+.logoContainer {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.barbedWire {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  height: auto;
+  z-index: 0;
+  opacity: 0.4;
+  filter: drop-shadow(2px 2px 2px rgb(0 0 0 / 0.5));
+}
+
+.logoText {
+  position: relative;
+  z-index: 1;
+  font-family: 'Bungee', sans-serif;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  transform: rotate(-2deg) skew(-3deg);
+  background: linear-gradient(90deg,
+    var(--keyword-color) 0%,
+    var(--function-color) 50%,
+    var(--type-color) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.5));
+}
+
+.small {
+  width: 120px;
+}


### PR DESCRIPTION
## Summary
- create shared `Logo.module.css` for barbed wire logo styling
- update `PromptHeader` and `HeroSection` to use shared styles
- resize and overlay barbed wire in `HeroSection` and prompt header

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68461e6bd5488330a7248f0290fc756b