### PR TITLE
Fix build types for Cloudflare Worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250610.0",
         "@eslint/js": "^9.21.0",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -337,6 +338,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250610.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250610.0.tgz",
+      "integrity": "sha512-HxnUoey3QxCEfy07pUm7J42jBi9YPHq/hA3fw6JmOqYLHdviHI28OA8lup+2RUaHwDzh6q1DSfrBvvDqde645A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250610.0",
     "@eslint/js": "^9.21.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",


### PR DESCRIPTION
## Summary
- add `@cloudflare/workers-types` so `tsc` knows the Worker types

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848626ddc30833093d77f4eb529a27f