### PR TITLE
Add Layout with Header for prompt pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,16 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
 import PromptPage from './pages/PromptPage';
+import Layout from './components/Layout';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<LandingPage />} />
-        <Route path="/prompts/:id" element={<PromptPage />} />
+        <Route element={<Layout />}>
+          <Route path="prompts/:id" element={<PromptPage />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+import Header from './Header';
+
+const Layout = () => (
+  <>
+    <Header />
+    <Outlet />
+  </>
+);
+
+export default Layout;

--- a/src/pages/PromptPage.tsx
+++ b/src/pages/PromptPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { ActionIcon, Code, Container, CopyButton, Loader, Title, Tooltip } from '@mantine/core';
 import { IconCopy, IconCheck } from '@tabler/icons-react';
-import Header from '../components/Header';
 import { prompts } from '../data/prompts';
 import classes from './PromptPage.module.css';
 
@@ -26,37 +25,34 @@ const PromptPage = () => {
   }, [prompt]);
 
   return (
-    <>
-      <Header />
-      <Container size="md" my="xl">
-        <Title order={1} className={classes.title}>{prompt ? prompt.title : 'Not Found'}</Title>
-        {loading ? (
-          <Loader />
-        ) : (
-          <div style={{ position: 'relative' }}>
-            <Code block className={classes.codeBlock}>{content}</Code>
-            <CopyButton value={content}>
-              {({ copied, copy }) => (
-                <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow position="left">
-                  <ActionIcon
-                    color={copied ? 'teal' : 'gray'}
-                    variant="subtle"
-                    onClick={copy}
-                    style={{
-                      position: 'absolute',
-                      top: '8px',
-                      right: '8px',
-                    }}
-                  >
-                    {copied ? <IconCheck size={16} /> : <IconCopy size={16} />}
-                  </ActionIcon>
-                </Tooltip>
-              )}
-            </CopyButton>
-          </div>
-        )}
-      </Container>
-    </>
+    <Container size="md" my="xl">
+      <Title order={1} className={classes.title}>{prompt ? prompt.title : 'Not Found'}</Title>
+      {loading ? (
+        <Loader />
+      ) : (
+        <div style={{ position: 'relative' }}>
+          <Code block className={classes.codeBlock}>{content}</Code>
+          <CopyButton value={content}>
+            {({ copied, copy }) => (
+              <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow position="left">
+                <ActionIcon
+                  color={copied ? 'teal' : 'gray'}
+                  variant="subtle"
+                  onClick={copy}
+                  style={{
+                    position: 'absolute',
+                    top: '8px',
+                    right: '8px',
+                  }}
+                >
+                  {copied ? <IconCheck size={16} /> : <IconCopy size={16} />}
+                </ActionIcon>
+              </Tooltip>
+            )}
+          </CopyButton>
+        </div>
+      )}
+    </Container>
   );
 };
 


### PR DESCRIPTION
## Summary
- create a simple layout component with the shared `Header`
- use the new layout for the prompt page route
- remove direct `Header` usage from `PromptPage`

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find name 'Request')*

------
https://chatgpt.com/codex/tasks/task_e_684a0a3a5210833083a925f92c3784d4