### PR TITLE
Add Audit, Create, and Debug pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
 import PromptPage from './pages/PromptPage';
+import AuditPage from './pages/AuditPage';
+import CreatePage from './pages/CreatePage';
+import DebugPage from './pages/DebugPage';
 import Layout from './components/Layout';
 
 function App() {
@@ -10,6 +13,9 @@ function App() {
         <Route path="/" element={<LandingPage />} />
         <Route element={<Layout />}>
           <Route path="prompts/:id" element={<PromptPage />} />
+          <Route path="audit" element={<AuditPage />} />
+          <Route path="create" element={<CreatePage />} />
+          <Route path="debug" element={<DebugPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/pages/AuditPage.tsx
+++ b/src/pages/AuditPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Container, Stack, Title, Text } from '@mantine/core';
+
+const AuditPage: React.FC = () => (
+  <Container size="md" my="xl">
+    <Stack gap="md">
+      <Title order={1}>Audit</Title>
+
+      <Title order={2}>Accessibility Audit Guidance</Title>
+      <Text>
+        The Accessibility Audit Guidance prompt transforms a piece of UI—be it code snippets, design mockups, or live web pages—into a comprehensive audit report aligned with WCAG, Section 508, and ADA guidelines. At its core, you feed it your markup or screenshots along with context about your target users (e.g., people with low vision, motor impairments, cognitive differences), and it returns a prioritized list of issues (from high-severity barriers to optional “nice-to-haves”), complete with recommended code fixes, ARIA attributes, and design adjustments. Rather than just flagging failures, it often surfaces the why behind each issue, linking technical mistakes to real-world user frustrations—ensuring the feedback remains grounded in human experience.
+      </Text>
+      <Text>
+        A less obvious strength lies in its intersectional lens: it doesn’t treat “accessibility” as a monolith but invites you to consider diverse modes of perception and interaction. For example, it may alert you that your color contrast is fine for most but still problematic for certain types of color blindness, or that keyboard-only navigation uncovers hidden focus traps affecting screen-reader users. It can even prompt you to run simple manual tests—like using voice controls or switching off styles—to verify automated findings, pushing beyond pure code analysis into participatory design territory. This dynamic, two-way auditing style helps teams co-create solutions with the very communities they intend to serve.
+      </Text>
+
+      <Title order={2}>Security Hardening Blueprint</Title>
+      <Text>
+        The Security Hardening Blueprint prompt serves as your AI-powered red team engineer. You present it with your application architecture, codebase excerpts, or deployment configuration, and it walks through a threat modeling exercise: identifying potential attack vectors (SQL injection, misconfigured CORS, insecure dependencies), recommending guardrails (parameterized queries, strict CSP, dependency pinning), and mapping out an incident response playbook. It also offers concrete CLI commands or code snippets for tools like OpenSSL, OWASP ZAP, or static analyzers, turning abstract security principles into actionable steps.
+      </Text>
+      <Text>
+        Beneath the surface, it’s optimized for AI-specific vulnerabilities: model poisoning, prompt injection, data leakage through logs, or inference attacks on your endpoints. It will push you to think like an adversary—what happens if someone queries your embedding store, manipulates API tokens, or chains known CVEs in your container images? Even more subtly, it layers in a risk-prioritization framework, weighing each recommendation against impact and implementation cost so you can triage effectively. By inviting you to reflect on organizational constraints (time, skills, compliance mandates), it fosters a dialogic approach: security isn’t a checkbox but an evolving collaboration between your team and the ever-shifting threat landscape.
+      </Text>
+    </Stack>
+  </Container>
+);
+
+export default AuditPage;

--- a/src/pages/CreatePage.tsx
+++ b/src/pages/CreatePage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Container, Stack, Title, Text } from '@mantine/core';
+
+const CreatePage: React.FC = () => (
+  <Container size="md" my="xl">
+    <Stack gap="md">
+      <Title order={1}>Create</Title>
+
+      <Title order={2}>Idea Refinement</Title>
+      <Text>
+        Idea Refinement prompt acts as a collaborative brainstorming partner to help users flesh out raw project or feature concepts into well-structured, actionable requests. At its core, it solicits an initial PROJECT_REQUEST and then dynamically guides the conversation by asking targeted clarifying questions, surfacing missing user flows, and suggesting perspectives that the user might not have considered. It’s designed not to hand you a fully formed spec immediately, but to engage you in a dialogue—inviting you to co-create the scope, goals, and edge cases before moving forward.
+      </Text>
+      <Text>
+        A less obvious strength of this prompt is its built-in mechanism for surfacing “unknown unknowns.” By explicitly prompting the AI to suggest missing considerations or user flows, it mirrors an anthropological approach—drawing on experiential knowledge rather than just technical checklists. This helps prevent tunnel vision and encourages a plurality of viewpoints, including potential accessibility, cultural, or regulatory constraints that might otherwise go unnoticed.
+      </Text>
+
+      <Title order={2}>Technical Specification Generation</Title>
+      <Text>
+        The Technical Specification Generation prompt is your blueprint architect: given a raw REQUEST and any RULES or best practices, it constructs a detailed, markdown-structured spec suitable for guiding engineers or code-generation AIs. It begins with an internal planning section where the AI maps out high-level architecture, data flows, and integration points before delivering the final spec in one of two templates. This two-phase design ensures both depth and structure, reducing the risk of missing critical system components.
+      </Text>
+      <Text>
+        A special feature of this prompt is its dual-template flexibility. Whether you’re green-fielding a product or iterating on an existing codebase, it automatically chooses the right layout—covering everything from API endpoints and database schemas to UI components and background jobs. It even scaffolds a design system section with accessibility considerations baked in, pushing beyond bare-bones technical specs to include visual style, theming, and responsive breakpoints.
+      </Text>
+
+      <Title order={2}>Implementation Plan Generation</Title>
+      <Text>
+        Think of the Implementation Plan Generation prompt as the project manager for a code-generation AI: it transforms a technical specification into a step-by-step roadmap that a script or developer can follow sequentially. It requires you to supply PROJECT_REQUEST, PROJECT_RULES, TECHNICAL_SPECIFICATION, and optional reference code, then issues a two-part output: a brainstorming tag capturing the logic behind the plan and a detailed markdown checklist of discrete, self-contained tasks.
+      </Text>
+      <Text>
+        What’s easily overlooked is its emphasis on granularity and isolation—each task is meant to be atomic, avoiding the ambiguity that can derail automated code generators. It also signals to the AI to consider shared components, authentication flows, and database migrations in a holistic fashion, smoothing the handoff between planning and coding. By embedding the brainstorming rationale, it preserves the why behind each step, which is crucial for audits and future iterations.
+      </Text>
+
+      <Title order={2}>Code Generation</Title>
+      <Text>
+        The Code Generation prompt functions like a master craftsman’s instruction manual: given an IMPLEMENTATION_PLAN, TECHNICAL_SPECIFICATION, and PROJECT_REQUEST (plus optional PROJECT_RULES and EXISTING_CODE), it systematically implements the next step in the plan. Instead of dumping all code at once, it tracks progress, reviews which checklist items are done, and then produces the precise files or modifications needed for the current step.
+      </Text>
+      <Text>
+        A subtle but powerful aspect is its insistence on complete file contents and adherence to strict documentation conventions. This prevents half-baked code snippets and encourages consistent styling. It’s effectively a single-step code generator, reducing merge conflicts and making incremental reviews easier—much like a developer pair-programming one function at a time.
+      </Text>
+    </Stack>
+  </Container>
+);
+
+export default CreatePage;

--- a/src/pages/DebugPage.tsx
+++ b/src/pages/DebugPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Container, Stack, Title, Text } from '@mantine/core';
+
+const DebugPage: React.FC = () => (
+  <Container size="md" my="xl">
+    <Stack gap="md">
+      <Title order={1}>Debug</Title>
+
+      <Title order={2}>Observe</Title>
+      <Text>
+        In the Observe phase of the OODA loop, this prompt positions the AI as a forensic investigator. It parses the user’s bug report and context, summarizes key observations without regurgitating long dumps, and highlights patterns or missing details. Crucially, it also asks clarifying questions to surface any gaps in information, such as environment specifics or error logs, before proceeding.
+      </Text>
+      <Text>
+        Its special feature is the structured checklist format, which helps maintain focus on the most relevant data points—user inputs, system state, and immediate anomalies. By explicitly separating observations from questions, it fosters a clear dialogue where the user and AI collaboratively build a complete picture of the issue.
+      </Text>
+
+      <Title order={2}>Orient</Title>
+      <Text>
+        The Orient phase takes the insights from Observe, integrates new clarifications, and begins to form hypotheses about root causes. This prompt directs the AI to review the summarized context, identify suspicious patterns like memory leaks or version mismatches, and organize these findings into logical groupings. It’s akin to a rapid analysis session where you make sense of the data before acting.
+      </Text>
+      <Text>
+        Subtly, it pushes the AI to consider broader systemic factors—dependencies, recent deployments, or third-party changes—that aren’t obvious from the initial bug report. This wider lens can surface power asymmetries in the tech stack and invite discussion about alternative debugging approaches.
+      </Text>
+
+      <Title order={2}>Decide</Title>
+      <Text>
+        In the Decide phase, the AI reviews the hypotheses and any constraints like time, risk tolerance, and resource availability to propose a handful of viable next steps. These might include gathering more logs, rolling back a release, or applying a targeted patch. Each option comes with a pros and cons analysis, so the user can weigh trade-offs and choose the path best aligned with their priorities.
+      </Text>
+      <Text>
+        What’s not immediately obvious is its encouragement of risk-aware decision-making: by asking the AI to factor in constraints, the prompt mimics real-world incident response where quick fixes must be balanced against system stability and user impact. This fosters dialogue rather than a prescriptive approach.
+      </Text>
+
+      <Title order={2}>Act</Title>
+      <Text>
+        Finally, the Act phase turns the chosen decision into concrete implementation steps. The prompt interprets the user’s selected action and guides them through specific tasks: code changes, configuration tweaks, or rollbacks. It also suggests validation and testing strategies like unit tests or smoke tests to confirm that the fix worked.
+      </Text>
+      <Text>
+        A key nuance is its dual focus on execution and verification. It reminds the user not only how to apply the change but how to measure success, closing the OODA loop and laying the groundwork for continuous improvement. This integration of action with validation embodies a cybernetic feedback loop, ensuring that each intervention is both deliberate and observable.
+      </Text>
+    </Stack>
+  </Container>
+);
+
+export default DebugPage;


### PR DESCRIPTION
## Summary
- create AuditPage, CreatePage and DebugPage
- wire them up in the router

## Testing
- `npm run lint`
- `npx tsc --project tsconfig.app.json --noEmit`
- `npm run build` *(fails: src/worker.ts missing DOM types)*

------
https://chatgpt.com/codex/tasks/task_e_684a0ba6cc2483308668d71e3b20c4e8