### PR TITLE
Add mode page navigation

### DIFF
--- a/src/components/BackHomeButton.module.css
+++ b/src/components/BackHomeButton.module.css
@@ -1,0 +1,23 @@
+.backContainer {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.backButton {
+  font-family: 'Bungee', sans-serif;
+  font-size: 1.2rem;
+  color: var(--function-color);
+  padding: 0.3rem 0.8rem;
+  background-color: rgba(0, 0, 0, 0.6);
+  border: 2px dashed var(--keyword-color);
+  text-transform: uppercase;
+  text-decoration: none;
+  display: inline-block;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.5));
+  transition: transform 0.2s ease;
+}
+
+.backButton:hover {
+  transform: scale(1.05) rotate(-2deg);
+  color: var(--keyword-color);
+}

--- a/src/components/BackHomeButton.tsx
+++ b/src/components/BackHomeButton.tsx
@@ -1,0 +1,13 @@
+import { Anchor } from '@mantine/core';
+import { Link } from 'react-router-dom';
+import classes from './BackHomeButton.module.css';
+
+const BackHomeButton = () => (
+  <div className={classes.backContainer}>
+    <Anchor component={Link} to="/" className={classes.backButton}>
+      Back to Home
+    </Anchor>
+  </div>
+);
+
+export default BackHomeButton;

--- a/src/components/ModeFooter.module.css
+++ b/src/components/ModeFooter.module.css
@@ -1,0 +1,22 @@
+.footer {
+  margin-top: 3rem;
+  padding: 1rem 0;
+  border-top: 3px dashed var(--type-color);
+  background-color: rgba(10, 10, 10, 0.8);
+  text-align: center;
+}
+
+.link {
+  margin: 0 1.5rem;
+  font-family: 'Metal Mania', cursive;
+  font-size: 1.5rem;
+  color: var(--function-color);
+  text-decoration: none;
+  text-shadow: 2px 2px 0 var(--mantine-color-dark-9);
+  transition: transform 0.2s ease;
+}
+
+.link:hover {
+  transform: rotate(-2deg) scale(1.1);
+  color: var(--keyword-color);
+}

--- a/src/components/ModeFooter.tsx
+++ b/src/components/ModeFooter.tsx
@@ -1,0 +1,21 @@
+import { Anchor, Group } from '@mantine/core';
+import { Link } from 'react-router-dom';
+import classes from './ModeFooter.module.css';
+
+const ModeFooter = () => (
+  <footer className={classes.footer}>
+    <Group justify="center">
+      <Anchor component={Link} to="/create" className={classes.link}>
+        Create
+      </Anchor>
+      <Anchor component={Link} to="/audit" className={classes.link}>
+        Audit
+      </Anchor>
+      <Anchor component={Link} to="/debug" className={classes.link}>
+        Debug
+      </Anchor>
+    </Group>
+  </footer>
+);
+
+export default ModeFooter;

--- a/src/pages/AuditPage.tsx
+++ b/src/pages/AuditPage.tsx
@@ -1,28 +1,34 @@
 import React from 'react';
 import { Container, Stack, Title, Text } from '@mantine/core';
+import BackHomeButton from '../components/BackHomeButton';
+import ModeFooter from '../components/ModeFooter';
 
 const AuditPage: React.FC = () => (
-  <Container size="md" my="xl">
-    <Stack gap="md">
-      <Title order={1}>Audit</Title>
+  <>
+    <BackHomeButton />
+    <Container size="md" my="xl">
+      <Stack gap="md">
+        <Title order={1}>Audit</Title>
 
-      <Title order={2}>Accessibility Audit Guidance</Title>
-      <Text>
-        The Accessibility Audit Guidance prompt transforms a piece of UI—be it code snippets, design mockups, or live web pages—into a comprehensive audit report aligned with WCAG, Section 508, and ADA guidelines. At its core, you feed it your markup or screenshots along with context about your target users (e.g., people with low vision, motor impairments, cognitive differences), and it returns a prioritized list of issues (from high-severity barriers to optional “nice-to-haves”), complete with recommended code fixes, ARIA attributes, and design adjustments. Rather than just flagging failures, it often surfaces the why behind each issue, linking technical mistakes to real-world user frustrations—ensuring the feedback remains grounded in human experience.
-      </Text>
-      <Text>
-        A less obvious strength lies in its intersectional lens: it doesn’t treat “accessibility” as a monolith but invites you to consider diverse modes of perception and interaction. For example, it may alert you that your color contrast is fine for most but still problematic for certain types of color blindness, or that keyboard-only navigation uncovers hidden focus traps affecting screen-reader users. It can even prompt you to run simple manual tests—like using voice controls or switching off styles—to verify automated findings, pushing beyond pure code analysis into participatory design territory. This dynamic, two-way auditing style helps teams co-create solutions with the very communities they intend to serve.
-      </Text>
+        <Title order={2}>Accessibility Audit Guidance</Title>
+        <Text>
+          The Accessibility Audit Guidance prompt transforms a piece of UI—be it code snippets, design mockups, or live web pages—into a comprehensive audit report aligned with WCAG, Section 508, and ADA guidelines. At its core, you feed it your markup or screenshots along with context about your target users (e.g., people with low vision, motor impairments, cognitive differences), and it returns a prioritized list of issues (from high-severity barriers to optional “nice-to-haves”), complete with recommended code fixes, ARIA attributes, and design adjustments. Rather than just flagging failures, it often surfaces the why behind each issue, linking technical mistakes to real-world user frustrations—ensuring the feedback remains grounded in human experience.
+        </Text>
+        <Text>
+          A less obvious strength lies in its intersectional lens: it doesn’t treat “accessibility” as a monolith but invites you to consider diverse modes of perception and interaction. For example, it may alert you that your color contrast is fine for most but still problematic for certain types of color blindness, or that keyboard-only navigation uncovers hidden focus traps affecting screen-reader users. It can even prompt you to run simple manual tests—like using voice controls or switching off styles—to verify automated findings, pushing beyond pure code analysis into participatory design territory. This dynamic, two-way auditing style helps teams co-create solutions with the very communities they intend to serve.
+        </Text>
 
-      <Title order={2}>Security Hardening Blueprint</Title>
-      <Text>
-        The Security Hardening Blueprint prompt serves as your AI-powered red team engineer. You present it with your application architecture, codebase excerpts, or deployment configuration, and it walks through a threat modeling exercise: identifying potential attack vectors (SQL injection, misconfigured CORS, insecure dependencies), recommending guardrails (parameterized queries, strict CSP, dependency pinning), and mapping out an incident response playbook. It also offers concrete CLI commands or code snippets for tools like OpenSSL, OWASP ZAP, or static analyzers, turning abstract security principles into actionable steps.
-      </Text>
-      <Text>
-        Beneath the surface, it’s optimized for AI-specific vulnerabilities: model poisoning, prompt injection, data leakage through logs, or inference attacks on your endpoints. It will push you to think like an adversary—what happens if someone queries your embedding store, manipulates API tokens, or chains known CVEs in your container images? Even more subtly, it layers in a risk-prioritization framework, weighing each recommendation against impact and implementation cost so you can triage effectively. By inviting you to reflect on organizational constraints (time, skills, compliance mandates), it fosters a dialogic approach: security isn’t a checkbox but an evolving collaboration between your team and the ever-shifting threat landscape.
-      </Text>
-    </Stack>
-  </Container>
+        <Title order={2}>Security Hardening Blueprint</Title>
+        <Text>
+          The Security Hardening Blueprint prompt serves as your AI-powered red team engineer. You present it with your application architecture, codebase excerpts, or deployment configuration, and it walks through a threat modeling exercise: identifying potential attack vectors (SQL injection, misconfigured CORS, insecure dependencies), recommending guardrails (parameterized queries, strict CSP, dependency pinning), and mapping out an incident response playbook. It also offers concrete CLI commands or code snippets for tools like OpenSSL, OWASP ZAP, or static analyzers, turning abstract security principles into actionable steps.
+        </Text>
+        <Text>
+          Beneath the surface, it’s optimized for AI-specific vulnerabilities: model poisoning, prompt injection, data leakage through logs, or inference attacks on your endpoints. It will push you to think like an adversary—what happens if someone queries your embedding store, manipulates API tokens, or chains known CVEs in your container images? Even more subtly, it layers in a risk-prioritization framework, weighing each recommendation against impact and implementation cost so you can triage effectively. By inviting you to reflect on organizational constraints (time, skills, compliance mandates), it fosters a dialogic approach: security isn’t a checkbox but an evolving collaboration between your team and the ever-shifting threat landscape.
+        </Text>
+      </Stack>
+    </Container>
+    <ModeFooter />
+  </>
 );
 
 export default AuditPage;

--- a/src/pages/CreatePage.tsx
+++ b/src/pages/CreatePage.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { Container, Stack, Title, Text } from '@mantine/core';
+import BackHomeButton from '../components/BackHomeButton';
+import ModeFooter from '../components/ModeFooter';
 
 const CreatePage: React.FC = () => (
-  <Container size="md" my="xl">
-    <Stack gap="md">
-      <Title order={1}>Create</Title>
+  <>
+    <BackHomeButton />
+    <Container size="md" my="xl">
+      <Stack gap="md">
+        <Title order={1}>Create</Title>
 
       <Title order={2}>Idea Refinement</Title>
       <Text>
@@ -37,8 +41,10 @@ const CreatePage: React.FC = () => (
       <Text>
         A subtle but powerful aspect is its insistence on complete file contents and adherence to strict documentation conventions. This prevents half-baked code snippets and encourages consistent styling. It’s effectively a single-step code generator, reducing merge conflicts and making incremental reviews easier—much like a developer pair-programming one function at a time.
       </Text>
-    </Stack>
-  </Container>
+      </Stack>
+    </Container>
+    <ModeFooter />
+  </>
 );
 
 export default CreatePage;

--- a/src/pages/DebugPage.tsx
+++ b/src/pages/DebugPage.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { Container, Stack, Title, Text } from '@mantine/core';
+import BackHomeButton from '../components/BackHomeButton';
+import ModeFooter from '../components/ModeFooter';
 
 const DebugPage: React.FC = () => (
-  <Container size="md" my="xl">
-    <Stack gap="md">
-      <Title order={1}>Debug</Title>
+  <>
+    <BackHomeButton />
+    <Container size="md" my="xl">
+      <Stack gap="md">
+        <Title order={1}>Debug</Title>
 
       <Title order={2}>Observe</Title>
       <Text>
@@ -37,8 +41,10 @@ const DebugPage: React.FC = () => (
       <Text>
         A key nuance is its dual focus on execution and verification. It reminds the user not only how to apply the change but how to measure success, closing the OODA loop and laying the groundwork for continuous improvement. This integration of action with validation embodies a cybernetic feedback loop, ensuring that each intervention is both deliberate and observable.
       </Text>
-    </Stack>
-  </Container>
+      </Stack>
+    </Container>
+    <ModeFooter />
+  </>
 );
 
 export default DebugPage;


### PR DESCRIPTION
## Summary
- add `BackHomeButton` and `ModeFooter` components
- show back button and mode footer on Audit, Create and Debug pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a252ff8cc8330930d2a13d67c8675