### PR TITLE
Add links to prompts and breadcrumb navigation

### DIFF
--- a/src/pages/AuditPage.tsx
+++ b/src/pages/AuditPage.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { Container, Stack, Title, Text } from '@mantine/core';
+import { Container, Stack, Title, Text, Anchor } from '@mantine/core';
+import { Link } from 'react-router-dom';
+import classes from './ModePage.module.css';
 
 const AuditPage: React.FC = () => (
   <Container size="md" my="xl">
     <Stack gap="md">
       <Title order={1}>Audit</Title>
 
-      <Title order={2}>Accessibility Audit Guidance</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/audit-a11y">
+          Accessibility Audit Guidance
+        </Anchor>
+      </Title>
       <Text>
         The Accessibility Audit Guidance prompt transforms a piece of UI—be it code snippets, design mockups, or live web pages—into a comprehensive audit report aligned with WCAG, Section 508, and ADA guidelines. At its core, you feed it your markup or screenshots along with context about your target users (e.g., people with low vision, motor impairments, cognitive differences), and it returns a prioritized list of issues (from high-severity barriers to optional “nice-to-haves”), complete with recommended code fixes, ARIA attributes, and design adjustments. Rather than just flagging failures, it often surfaces the why behind each issue, linking technical mistakes to real-world user frustrations—ensuring the feedback remains grounded in human experience.
       </Text>
@@ -14,7 +20,11 @@ const AuditPage: React.FC = () => (
         A less obvious strength lies in its intersectional lens: it doesn’t treat “accessibility” as a monolith but invites you to consider diverse modes of perception and interaction. For example, it may alert you that your color contrast is fine for most but still problematic for certain types of color blindness, or that keyboard-only navigation uncovers hidden focus traps affecting screen-reader users. It can even prompt you to run simple manual tests—like using voice controls or switching off styles—to verify automated findings, pushing beyond pure code analysis into participatory design territory. This dynamic, two-way auditing style helps teams co-create solutions with the very communities they intend to serve.
       </Text>
 
-      <Title order={2}>Security Hardening Blueprint</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/audit-security">
+          Security Hardening Blueprint
+        </Anchor>
+      </Title>
       <Text>
         The Security Hardening Blueprint prompt serves as your AI-powered red team engineer. You present it with your application architecture, codebase excerpts, or deployment configuration, and it walks through a threat modeling exercise: identifying potential attack vectors (SQL injection, misconfigured CORS, insecure dependencies), recommending guardrails (parameterized queries, strict CSP, dependency pinning), and mapping out an incident response playbook. It also offers concrete CLI commands or code snippets for tools like OpenSSL, OWASP ZAP, or static analyzers, turning abstract security principles into actionable steps.
       </Text>

--- a/src/pages/CreatePage.tsx
+++ b/src/pages/CreatePage.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { Container, Stack, Title, Text } from '@mantine/core';
+import { Container, Stack, Title, Text, Anchor } from '@mantine/core';
+import { Link } from 'react-router-dom';
+import classes from './ModePage.module.css';
 
 const CreatePage: React.FC = () => (
   <Container size="md" my="xl">
     <Stack gap="md">
       <Title order={1}>Create</Title>
 
-      <Title order={2}>Idea Refinement</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/create-request">
+          Idea Refinement
+        </Anchor>
+      </Title>
       <Text>
         Idea Refinement prompt acts as a collaborative brainstorming partner to help users flesh out raw project or feature concepts into well-structured, actionable requests. At its core, it solicits an initial PROJECT_REQUEST and then dynamically guides the conversation by asking targeted clarifying questions, surfacing missing user flows, and suggesting perspectives that the user might not have considered. It’s designed not to hand you a fully formed spec immediately, but to engage you in a dialogue—inviting you to co-create the scope, goals, and edge cases before moving forward.
       </Text>
@@ -14,7 +20,11 @@ const CreatePage: React.FC = () => (
         A less obvious strength of this prompt is its built-in mechanism for surfacing “unknown unknowns.” By explicitly prompting the AI to suggest missing considerations or user flows, it mirrors an anthropological approach—drawing on experiential knowledge rather than just technical checklists. This helps prevent tunnel vision and encourages a plurality of viewpoints, including potential accessibility, cultural, or regulatory constraints that might otherwise go unnoticed.
       </Text>
 
-      <Title order={2}>Technical Specification Generation</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/create-spec">
+          Technical Specification Generation
+        </Anchor>
+      </Title>
       <Text>
         The Technical Specification Generation prompt is your blueprint architect: given a raw REQUEST and any RULES or best practices, it constructs a detailed, markdown-structured spec suitable for guiding engineers or code-generation AIs. It begins with an internal planning section where the AI maps out high-level architecture, data flows, and integration points before delivering the final spec in one of two templates. This two-phase design ensures both depth and structure, reducing the risk of missing critical system components.
       </Text>
@@ -22,7 +32,11 @@ const CreatePage: React.FC = () => (
         A special feature of this prompt is its dual-template flexibility. Whether you’re green-fielding a product or iterating on an existing codebase, it automatically chooses the right layout—covering everything from API endpoints and database schemas to UI components and background jobs. It even scaffolds a design system section with accessibility considerations baked in, pushing beyond bare-bones technical specs to include visual style, theming, and responsive breakpoints.
       </Text>
 
-      <Title order={2}>Implementation Plan Generation</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/create-planner">
+          Implementation Plan Generation
+        </Anchor>
+      </Title>
       <Text>
         Think of the Implementation Plan Generation prompt as the project manager for a code-generation AI: it transforms a technical specification into a step-by-step roadmap that a script or developer can follow sequentially. It requires you to supply PROJECT_REQUEST, PROJECT_RULES, TECHNICAL_SPECIFICATION, and optional reference code, then issues a two-part output: a brainstorming tag capturing the logic behind the plan and a detailed markdown checklist of discrete, self-contained tasks.
       </Text>
@@ -30,7 +44,11 @@ const CreatePage: React.FC = () => (
         What’s easily overlooked is its emphasis on granularity and isolation—each task is meant to be atomic, avoiding the ambiguity that can derail automated code generators. It also signals to the AI to consider shared components, authentication flows, and database migrations in a holistic fashion, smoothing the handoff between planning and coding. By embedding the brainstorming rationale, it preserves the why behind each step, which is crucial for audits and future iterations.
       </Text>
 
-      <Title order={2}>Code Generation</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/create-codegen">
+          Code Generation
+        </Anchor>
+      </Title>
       <Text>
         The Code Generation prompt functions like a master craftsman’s instruction manual: given an IMPLEMENTATION_PLAN, TECHNICAL_SPECIFICATION, and PROJECT_REQUEST (plus optional PROJECT_RULES and EXISTING_CODE), it systematically implements the next step in the plan. Instead of dumping all code at once, it tracks progress, reviews which checklist items are done, and then produces the precise files or modifications needed for the current step.
       </Text>

--- a/src/pages/DebugPage.tsx
+++ b/src/pages/DebugPage.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import { Container, Stack, Title, Text } from '@mantine/core';
+import { Container, Stack, Title, Text, Anchor } from '@mantine/core';
+import { Link } from 'react-router-dom';
+import classes from './ModePage.module.css';
 
 const DebugPage: React.FC = () => (
   <Container size="md" my="xl">
     <Stack gap="md">
       <Title order={1}>Debug</Title>
 
-      <Title order={2}>Observe</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/debug-observe">Observe</Anchor>
+      </Title>
       <Text>
         In the Observe phase of the OODA loop, this prompt positions the AI as a forensic investigator. It parses the user’s bug report and context, summarizes key observations without regurgitating long dumps, and highlights patterns or missing details. Crucially, it also asks clarifying questions to surface any gaps in information, such as environment specifics or error logs, before proceeding.
       </Text>
@@ -14,7 +18,9 @@ const DebugPage: React.FC = () => (
         Its special feature is the structured checklist format, which helps maintain focus on the most relevant data points—user inputs, system state, and immediate anomalies. By explicitly separating observations from questions, it fosters a clear dialogue where the user and AI collaboratively build a complete picture of the issue.
       </Text>
 
-      <Title order={2}>Orient</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/debug-orient">Orient</Anchor>
+      </Title>
       <Text>
         The Orient phase takes the insights from Observe, integrates new clarifications, and begins to form hypotheses about root causes. This prompt directs the AI to review the summarized context, identify suspicious patterns like memory leaks or version mismatches, and organize these findings into logical groupings. It’s akin to a rapid analysis session where you make sense of the data before acting.
       </Text>
@@ -22,7 +28,9 @@ const DebugPage: React.FC = () => (
         Subtly, it pushes the AI to consider broader systemic factors—dependencies, recent deployments, or third-party changes—that aren’t obvious from the initial bug report. This wider lens can surface power asymmetries in the tech stack and invite discussion about alternative debugging approaches.
       </Text>
 
-      <Title order={2}>Decide</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/debug-decide">Decide</Anchor>
+      </Title>
       <Text>
         In the Decide phase, the AI reviews the hypotheses and any constraints like time, risk tolerance, and resource availability to propose a handful of viable next steps. These might include gathering more logs, rolling back a release, or applying a targeted patch. Each option comes with a pros and cons analysis, so the user can weigh trade-offs and choose the path best aligned with their priorities.
       </Text>
@@ -30,7 +38,9 @@ const DebugPage: React.FC = () => (
         What’s not immediately obvious is its encouragement of risk-aware decision-making: by asking the AI to factor in constraints, the prompt mimics real-world incident response where quick fixes must be balanced against system stability and user impact. This fosters dialogue rather than a prescriptive approach.
       </Text>
 
-      <Title order={2}>Act</Title>
+      <Title order={2} className={classes.linkHeading}>
+        <Anchor component={Link} to="/prompts/debug-act">Act</Anchor>
+      </Title>
       <Text>
         Finally, the Act phase turns the chosen decision into concrete implementation steps. The prompt interprets the user’s selected action and guides them through specific tasks: code changes, configuration tweaks, or rollbacks. It also suggests validation and testing strategies like unit tests or smoke tests to confirm that the fix worked.
       </Text>

--- a/src/pages/ModePage.module.css
+++ b/src/pages/ModePage.module.css
@@ -1,0 +1,20 @@
+.linkHeading {
+  --mantine-font-family-headings: 'Permanent Marker', cursive;
+  color: var(--type-color, #79c0ff);
+  text-shadow: 0 0 4px var(--function-color, #d2a8ff);
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  transform: rotate(-1deg) skewX(-3deg);
+}
+
+.linkHeading a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease, text-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.linkHeading a:hover {
+  color: var(--keyword-color, #ff7b72);
+  text-shadow: 0 0 6px var(--keyword-color, #ff7b72);
+  transform: rotate(1deg) scale(1.05);
+}

--- a/src/pages/PromptPage.module.css
+++ b/src/pages/PromptPage.module.css
@@ -2,3 +2,19 @@
   font-size: 1rem;
   white-space: pre-wrap;
 }
+
+.breadcrumbs {
+  font-family: 'VT323', monospace;
+  font-size: 1.2rem;
+}
+
+.breadcrumbLink {
+  color: var(--type-color, #79c0ff);
+  text-decoration: none;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
+}
+
+.breadcrumbLink:hover {
+  color: var(--keyword-color, #ff7b72);
+  text-shadow: 0 0 6px var(--keyword-color, #ff7b72);
+}

--- a/src/pages/PromptPage.tsx
+++ b/src/pages/PromptPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { ActionIcon, Code, Container, CopyButton, Loader, Title, Tooltip } from '@mantine/core';
+import { ActionIcon, Code, Container, CopyButton, Loader, Title, Tooltip, Breadcrumbs, Anchor } from '@mantine/core';
+import { Link } from 'react-router-dom';
 import { IconCopy, IconCheck } from '@tabler/icons-react';
 import { prompts } from '../data/prompts';
 import classes from './PromptPage.module.css';
@@ -8,6 +9,7 @@ import classes from './PromptPage.module.css';
 const PromptPage = () => {
   const { id } = useParams<{ id: string }>();
   const prompt = prompts.find((p) => p.id === id);
+  const mode = id ? id.split('-')[0] : undefined;
 
   const [content, setContent] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
@@ -26,6 +28,17 @@ const PromptPage = () => {
 
   return (
     <Container size="md" my="xl">
+      <Breadcrumbs mb="sm" className={classes.breadcrumbs}>
+        <Anchor component={Link} to="/" className={classes.breadcrumbLink}>
+          Home
+        </Anchor>
+        {prompt && mode && (
+          <Anchor component={Link} to={`/${mode}`} className={classes.breadcrumbLink}>
+            {mode.charAt(0).toUpperCase() + mode.slice(1)}
+          </Anchor>
+        )}
+        <span>{prompt ? prompt.title : 'Not Found'}</span>
+      </Breadcrumbs>
       <Title order={1}>{prompt ? prompt.title : 'Not Found'}</Title>
       {loading ? (
         <Loader />


### PR DESCRIPTION
## Summary
- make subheaders on the Audit, Create and Debug pages link to their prompt pages
- show breadcrumb navigation on prompt pages
- spice up the design with styled mode headings and breadcrumbs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a25fd9944833095952419c7c68f9c