### PR TITLE
Switch mode pages to breadcrumb navigation

### DIFF
--- a/src/components/BackHomeButton.module.css
+++ b/src/components/BackHomeButton.module.css
@@ -1,23 +1,16 @@
-.backContainer {
-  text-align: center;
+.breadcrumbs {
+  font-family: 'VT323', monospace;
+  font-size: 1.2rem;
   margin-top: 1rem;
 }
 
-.backButton {
-  font-family: 'Bungee', sans-serif;
-  font-size: 1.2rem;
-  color: var(--function-color);
-  padding: 0.3rem 0.8rem;
-  background-color: rgba(0, 0, 0, 0.6);
-  border: 2px dashed var(--keyword-color);
-  text-transform: uppercase;
+.breadcrumbLink {
+  color: var(--type-color, #79c0ff);
   text-decoration: none;
-  display: inline-block;
-  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.5));
-  transition: transform 0.2s ease;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
 }
 
-.backButton:hover {
-  transform: scale(1.05) rotate(-2deg);
-  color: var(--keyword-color);
+.breadcrumbLink:hover {
+  color: var(--keyword-color, #ff7b72);
+  text-shadow: 0 0 6px var(--keyword-color, #ff7b72);
 }

--- a/src/components/BackHomeButton.tsx
+++ b/src/components/BackHomeButton.tsx
@@ -1,13 +1,18 @@
-import { Anchor } from '@mantine/core';
+import { Anchor, Breadcrumbs } from '@mantine/core';
 import { Link } from 'react-router-dom';
 import classes from './BackHomeButton.module.css';
 
-const BackHomeButton = () => (
-  <div className={classes.backContainer}>
-    <Anchor component={Link} to="/" className={classes.backButton}>
-      Back to Home
+interface BackHomeButtonProps {
+  mode: string;
+}
+
+const BackHomeButton = ({ mode }: BackHomeButtonProps) => (
+  <Breadcrumbs mb="sm" className={classes.breadcrumbs}>
+    <Anchor component={Link} to="/" className={classes.breadcrumbLink}>
+      Home
     </Anchor>
-  </div>
+    <span>{mode}</span>
+  </Breadcrumbs>
 );
 
 export default BackHomeButton;

--- a/src/pages/AuditPage.tsx
+++ b/src/pages/AuditPage.tsx
@@ -7,7 +7,7 @@ import classes from './ModePage.module.css';
 
 const AuditPage: React.FC = () => (
   <>
-    <BackHomeButton />
+    <BackHomeButton mode="Audit" />
     <Container size="md" my="xl">
       <Stack gap="md">
         <Title order={1}>Audit</Title>

--- a/src/pages/CreatePage.tsx
+++ b/src/pages/CreatePage.tsx
@@ -7,7 +7,7 @@ import classes from './ModePage.module.css';
 
 const CreatePage: React.FC = () => (
   <>
-    <BackHomeButton />
+    <BackHomeButton mode="Create" />
     <Container size="md" my="xl">
       <Stack gap="md">
         <Title order={1}>Create</Title>

--- a/src/pages/DebugPage.tsx
+++ b/src/pages/DebugPage.tsx
@@ -7,7 +7,7 @@ import classes from './ModePage.module.css';
 
 const DebugPage: React.FC = () => (
   <>
-    <BackHomeButton />
+    <BackHomeButton mode="Debug" />
     <Container size="md" my="xl">
       <Stack gap="md">
         <Title order={1}>Debug</Title>


### PR DESCRIPTION
## Summary
- transform `BackHomeButton` into a breadcrumb component
- give the breadcrumb component styling like PromptPage
- show `Home / {Mode}` breadcrumb on the Create, Audit and Debug pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a2bd820508330b5755852cf5bc4a7