### PR TITLE
Add accessibility route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import AuditPage from './pages/AuditPage';
 import CreatePage from './pages/CreatePage';
 import DebugPage from './pages/DebugPage';
 import PrivacyPage from './pages/PrivacyPage';
+import AccessibilityPage from './pages/AccessibilityPage';
 import Layout from './components/Layout';
 
 function App() {
@@ -22,6 +23,7 @@ function App() {
           <Route path="create" element={<CreatePage />} />
           <Route path="debug" element={<DebugPage />} />
           <Route path="privacy" element={<PrivacyPage />} />
+          <Route path="accessibility" element={<AccessibilityPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/pages/AccessibilityPage.tsx
+++ b/src/pages/AccessibilityPage.tsx
@@ -1,0 +1,14 @@
+import { Container, Title, Text } from '@mantine/core';
+
+const AccessibilityPage = () => (
+  <Container size="md" my="xl">
+    <Title order={1}>Accessibility</Title>
+    <Text mt="md">
+      This site should be accessible to everyone. If you run into any issues,
+      please send them to{' '}
+      <a href="mailto:accessibility@kornelius.dev">accessibility@kornelius.dev</a>.
+    </Text>
+  </Container>
+);
+
+export default AccessibilityPage;


### PR DESCRIPTION
## Summary
- add `AccessibilityPage` with contact info
- register `/accessibility` route in the router

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b5077a6e48330b0ba89b21ddcb329