### PR TITLE
Update home links to skip hero

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,7 @@ import ActionIcons from './ActionIcons';
 
 const PromptHeader = () => (
   <header className={classes.header}>
-    <Anchor component={Link} to="/" className={classes.logoLink}>
+    <Anchor component={Link} to="/#workflow-overview" className={classes.logoLink}>
       <div className={classNames(logoClasses.logoContainer, classes.logoContainer)}>
         <img src={logo} alt="Logo" className={classNames(logoClasses.barbedWire, classes.barbedWireSmall)} />
         <Text className={logoClasses.logoText}>KoЯnelius</Text>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -2,11 +2,18 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const ScrollToTop = () => {
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
 
   useEffect(() => {
+    if (hash) {
+      const element = document.getElementById(hash.substring(1));
+      if (element) {
+        element.scrollIntoView();
+        return;
+      }
+    }
     window.scrollTo(0, 0);
-  }, [pathname]);
+  }, [pathname, hash]);
 
   return null;
 };

--- a/src/pages/AuditPage.tsx
+++ b/src/pages/AuditPage.tsx
@@ -6,7 +6,7 @@ import classes from './ModePage.module.css';
 
 const AuditPage: React.FC = () => (
   <>
-    <PageBreadcrumbs items={[{ label: 'Home', to: '/' }, { label: 'Prompts', to: '/prompts' }, { label: 'Audit' }]} />
+    <PageBreadcrumbs items={[{ label: 'Home', to: '/#workflow-overview' }, { label: 'Prompts', to: '/prompts' }, { label: 'Audit' }]} />
     <Container size="md" my="xl">
       <Stack gap="md">
         <Title order={1}>Audit</Title>

--- a/src/pages/CreatePage.tsx
+++ b/src/pages/CreatePage.tsx
@@ -6,7 +6,7 @@ import classes from './ModePage.module.css';
 
 const CreatePage: React.FC = () => (
   <>
-    <PageBreadcrumbs items={[{ label: 'Home', to: '/' }, { label: 'Prompts', to: '/prompts' }, { label: 'Create' }]} />
+    <PageBreadcrumbs items={[{ label: 'Home', to: '/#workflow-overview' }, { label: 'Prompts', to: '/prompts' }, { label: 'Create' }]} />
     <Container size="md" my="xl">
       <Stack gap="md">
         <Title order={1}>Create</Title>

--- a/src/pages/DebugPage.tsx
+++ b/src/pages/DebugPage.tsx
@@ -6,7 +6,7 @@ import classes from './ModePage.module.css';
 
 const DebugPage: React.FC = () => (
   <>
-    <PageBreadcrumbs items={[{ label: 'Home', to: '/' }, { label: 'Prompts', to: '/prompts' }, { label: 'Debug' }]} />
+    <PageBreadcrumbs items={[{ label: 'Home', to: '/#workflow-overview' }, { label: 'Prompts', to: '/prompts' }, { label: 'Debug' }]} />
     <Container size="md" my="xl">
       <Stack gap="md">
         <Title order={1}>Debug</Title>

--- a/src/pages/PromptDetailPage.tsx
+++ b/src/pages/PromptDetailPage.tsx
@@ -30,7 +30,7 @@ const PromptPage = () => {
     <>
       <PageBreadcrumbs
         items={[
-          { label: 'Home', to: '/' },
+          { label: 'Home', to: '/#workflow-overview' },
           { label: 'Prompts', to: '/prompts' },
           ...(prompt && mode
             ? [{ label: mode.charAt(0).toUpperCase() + mode.slice(1), to: `/${mode}` }]

--- a/src/pages/PromptsIndexPage.tsx
+++ b/src/pages/PromptsIndexPage.tsx
@@ -6,7 +6,7 @@ import classes from './ModePage.module.css';
 
 const PromptsIndexPage: React.FC = () => (
   <>
-    <PageBreadcrumbs items={[{ label: 'Home', to: '/#' }, { label: 'Prompts' }]} />
+    <PageBreadcrumbs items={[{ label: 'Home', to: '/#workflow-overview' }, { label: 'Prompts' }]} />
     <Container size="md" my="xl">
       <Stack gap="md">
         <Title order={1}>Prompts</Title>


### PR DESCRIPTION
## Summary
- link header logo to `/#workflow-overview`
- update breadcrumbs to point to the "The Grand Scheme" section
- support hash-aware scrolling in ScrollToTop

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b547a4a948330b94d7a942aa4fe83